### PR TITLE
Split lenskit recbole envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ __pycache__
 /experiment_results/*
 /plots/*
 /profiler_runs/*
+/datasets/*
+/recbole_models/*
+
+.envs

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This project implements an agent-based model (ABM) to simulate the propagation o
 ### Model Architecture
 
 FakeNewsModel
+
 ```
 ├── SocialMediaPlatform
 │ ├── SocialNetwork (NetworkX directed graph)
@@ -28,13 +29,12 @@ FakeNewsModel
 └── DataCollector (Metrics and visualization)
 ```
 
-
-
 ## Dashboard
 
 ![Solara Dashboard](diagrams/solara_dashboard.png)
 
 The Solara dashboard provides an interactive interface to run and visualize the simulation. It allows you to:
+
 - Adjust simulation parameters in real-time
 - View the network graph with different agent types and states
 - Monitor key metrics as the simulation progresses
@@ -44,6 +44,7 @@ The Solara dashboard provides an interactive interface to run and visualize the 
 
 - pandas
 - numpy
+- torch
 - networkx
 - mesa
 - lenskit
@@ -54,7 +55,8 @@ The Solara dashboard provides an interactive interface to run and visualize the 
 - python-louvain
 - dppy
 - scikit-learn
-
+- pyyaml
+- recbole
 
 ## Project Structure
 
@@ -68,7 +70,14 @@ The Solara dashboard provides an interactive interface to run and visualize the 
 │ ├── social_network.py # Network structure
 │ └── social_media_platform.py # Platform orchestration
 ├── recommender/
-│ ├── recommender.py # Recommendation algorithms
+│ ├── lenskit
+│ │ ├── lenskit_recommender.py # Recommenders using lenskit library (lightweight, for experimentation)
+│ ├── recbole
+│ │ ├── recbole_recommender.py # Recommenders using recbole library (heavier, more modern algorithms)
+│ ├── base_recommender.py # Abstract recommender class
+│ ├── diversity.py # Calculate recommendation diversity
+│ ├── factory.py # Switch recommender type depending on library
+│ ├── general_recommender.py # General algorithms
 │ └── types.py # Algorithm type definitions
 ├── utils/
 │ ├── metrics.py # Evaluation metrics
@@ -107,11 +116,10 @@ python3.11 -m venv .venv
 .venv\Scripts\activate
 ```
 
-
 3. Install dependencies:
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements/lenskit.txt
 ```
 
 ## Usage
@@ -123,6 +131,7 @@ solara run model.py
 ```
 
 This will launch a Solara visualization interface where you can:
+
 - Adjust the number of agents (5-100)
 - Modify the number of edges per new node (1-5)
 - View network visualization
@@ -136,18 +145,20 @@ This will launch a Solara visualization interface where you can:
 ```bash
 python3 experiments.py
 ```
+
 You can modify the parameters in the `experiments.py` file.
 
 Experiment results are saved in the `experiment_results` folder.
 
 ### Plotting results
+
 After running experiments, you can generate plots to visualize the results:
 
 ```bash
 python3 plot.py experiment_results/{experiment_name}.csv --output-dir plots
 ```
-Remember to replace `{experiment_name}` with the name of the experiment file you want to plot, along with the correct timestamp.
 
+Remember to replace `{experiment_name}` with the name of the experiment file you want to plot, along with the correct timestamp.
 
 ## License
 

--- a/experiment_config.yaml
+++ b/experiment_config.yaml
@@ -1,0 +1,3 @@
+lenskit: ["random", "item_knn", "user_knn", "content_based", "popular"]
+
+recbole: ["BPR"]

--- a/experiments.py
+++ b/experiments.py
@@ -1,11 +1,11 @@
 import os
-import yaml
 
-
+# Safeguard against thread conficts across libraries
 os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
 os.environ["OMP_NUM_THREADS"] = "1"
 
 import mesa
+import yaml
 import pandas as pd
 import numpy as np
 from datetime import datetime

--- a/experiments.py
+++ b/experiments.py
@@ -14,6 +14,7 @@ from utils.network_storage import NetworkStorage
 
 
 def run_recommender_comparison_experiment(
+    library,
     iterations,
     max_steps,
     n_agents,
@@ -63,6 +64,7 @@ def run_recommender_comparison_experiment(
     # Create an initial model to generate and store the network with current parameters
     # Set use_stored_network=False to force creation of a new network
     initial_model = FakeNewsModel(
+        library=library,
         N=n_agents,
         m_links=m_links,
         news_amount=news_amount,
@@ -73,7 +75,7 @@ def run_recommender_comparison_experiment(
         num_recommendations=num_recommendations,
         use_stored_network=True,
         stored_network=None,  # Force creation of new network
-        recommender_type=RecommenderType.RANDOM.value,  # Use any recommender for initial setup
+        recommender_type="BPR",  # Use any recommender for initial setup
         max_steps=max_steps,
     )
 
@@ -89,6 +91,7 @@ def run_recommender_comparison_experiment(
     # Define parameters for batch run
     # We'll vary the recommender type while keeping other parameters fixed
     parameters = {
+        "library": library,
         "N": n_agents,
         "m_links": m_links,
         "news_amount": news_amount,
@@ -100,7 +103,7 @@ def run_recommender_comparison_experiment(
         "use_stored_network": True,  # Now use the stored network for all runs
         "network_file": network_file,  # Pass the network file path instead of the network object
         "stored_network": None,  # No longer needed
-        "recommender_type": [type.value for type in RecommenderType],
+        "recommender_type": "BPR",  # [type.value for type in RecommenderType],
         "max_steps": max_steps,
         "collect_personality_degree_stats": False,
         "collect_community_data": True,
@@ -282,10 +285,18 @@ def analyze_results(model_data, summary_df):
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate plots from experiment data")
+    parser.add_argument(
+        "library", type=str, help="Recommender library to use (lenskit/recbole)"
+    )
+    args = parser.parse_args()
 
     # Run the experiment
     results_df, model_data, summary_df, community_data_file = (
         run_recommender_comparison_experiment(
+            library=args.library,
             iterations=5,  # Number of runs per recommender type
             max_steps=700,  # Steps per run
             n_agents=200,  # Number of agents

--- a/experiments.py
+++ b/experiments.py
@@ -1,4 +1,6 @@
 import os
+import yaml
+
 
 os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
 os.environ["OMP_NUM_THREADS"] = "1"
@@ -6,7 +8,6 @@ os.environ["OMP_NUM_THREADS"] = "1"
 import mesa
 import pandas as pd
 import numpy as np
-import os
 from datetime import datetime
 from model import FakeNewsModel
 from recommender.types import RecommenderType
@@ -61,6 +62,9 @@ def run_recommender_comparison_experiment(
 
     NetworkStorage.clear()
 
+    with open("experiment_config.yaml", "r") as f:
+        config = yaml.load(f, Loader=yaml.SafeLoader)
+
     # Create an initial model to generate and store the network with current parameters
     # Set use_stored_network=False to force creation of a new network
     initial_model = FakeNewsModel(
@@ -75,7 +79,7 @@ def run_recommender_comparison_experiment(
         num_recommendations=num_recommendations,
         use_stored_network=True,
         stored_network=None,  # Force creation of new network
-        recommender_type="BPR",  # Use any recommender for initial setup
+        recommender_type=config[library][0],  # Use any recommender for initial setup
         max_steps=max_steps,
     )
 
@@ -103,7 +107,9 @@ def run_recommender_comparison_experiment(
         "use_stored_network": True,  # Now use the stored network for all runs
         "network_file": network_file,  # Pass the network file path instead of the network object
         "stored_network": None,  # No longer needed
-        "recommender_type": "BPR",  # [type.value for type in RecommenderType],
+        "recommender_type": [
+            rec for rec in config[library]
+        ],  # [type.value for type in RecommenderType],
         "max_steps": max_steps,
         "collect_personality_degree_stats": False,
         "collect_community_data": True,
@@ -297,7 +303,7 @@ if __name__ == "__main__":
     results_df, model_data, summary_df, community_data_file = (
         run_recommender_comparison_experiment(
             library=args.library,
-            iterations=5,  # Number of runs per recommender type
+            iterations=1,  # Number of runs per recommender type
             max_steps=700,  # Steps per run
             n_agents=200,  # Number of agents
             m_links=8,  # Links per new node

--- a/experiments.py
+++ b/experiments.py
@@ -1,3 +1,8 @@
+import os
+
+os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
+os.environ["OMP_NUM_THREADS"] = "1"
+
 import mesa
 import pandas as pd
 import numpy as np
@@ -110,7 +115,7 @@ def run_recommender_comparison_experiment(
         parameters=parameters,
         iterations=iterations,
         max_steps=max_steps,
-        number_processes=8,  # Set to higher number for parallel processing
+        number_processes=5,  # Set to higher number for parallel processing
         data_collection_period=1,  # Collect data at each step
         display_progress=True,
     )

--- a/model.py
+++ b/model.py
@@ -58,7 +58,7 @@ class FakeNewsModel(Model):
     # Initialize agents
     def __init__(
         self,
-        library: str = "default",  # WILL RAISE ERROR (on purpose)
+        library: str = "lenskit",  # WILL RAISE ERROR (on purpose)
         N: int = 200,
         m_links: int = 10,
         news_amount: int = 500,

--- a/model.py
+++ b/model.py
@@ -58,6 +58,7 @@ class FakeNewsModel(Model):
     # Initialize agents
     def __init__(
         self,
+        library: str = "default",  # WILL RAISE ERROR (on purpose)
         N: int = 200,
         m_links: int = 10,
         news_amount: int = 500,
@@ -87,6 +88,7 @@ class FakeNewsModel(Model):
         self.num_agents = N
         self.m_links = m_links
         self.fake_news_percentage = fake_news_percentage / 100
+        self.library = library
         self.recommender_type = recommender_type
         self.bot_percentage = bot_percentage / 100
         self.influencer_percentage = influencer_percentage / 100
@@ -117,6 +119,7 @@ class FakeNewsModel(Model):
             self.m_links,
             self.preference_vectors,
             self.personality_vectors,
+            self.library,
             self.recommender_type,
             self.diversity_level,
             self.num_recommendations,

--- a/objects/social_media_platform.py
+++ b/objects/social_media_platform.py
@@ -1,4 +1,4 @@
-from recommender.recommender import Recommender
+from recommender.factory import create_recommender
 from objects.social_network import Social_Network
 
 
@@ -10,6 +10,7 @@ class SocialMediaPlatform:
         m_links,
         preference_vectors,
         personality_vectors,
+        library,
         recommender_type,
         diversity_level,
         num_recommendations,
@@ -28,6 +29,6 @@ class SocialMediaPlatform:
         )
 
         # Create recommender system
-        self.recommender = Recommender(
-            recommender_type, diversity_level, num_recommendations
+        self.recommender = create_recommender(
+            library, recommender_type, diversity_level, num_recommendations
         )

--- a/recommender/base_recommender.py
+++ b/recommender/base_recommender.py
@@ -1,0 +1,12 @@
+from abc import ABC, abstractmethod
+
+
+class BaseRecommender(ABC):
+
+    @abstractmethod
+    def update_recommendations(self, agents):
+        pass
+
+    @abstractmethod
+    def add_interaction(self, agent_id, content_id, rating):
+        pass

--- a/recommender/base_recommender.py
+++ b/recommender/base_recommender.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 
 
+# Defines methods all recommenders have to include
 class BaseRecommender(ABC):
 
     @abstractmethod

--- a/recommender/factory.py
+++ b/recommender/factory.py
@@ -1,0 +1,19 @@
+def create_recommender(library, recommender_type, diversity_level, num_recommendations):
+    if library == "lenskit":
+        from recommender.lenskit.lenskit_recommender import LenskitRecommender
+
+        return LenskitRecommender(
+            recommender_type, diversity_level, num_recommendations
+        )
+
+    elif library == "recbole":
+        from recommender.recbole.recbole_recommender import RecboleRecommender
+
+        return RecboleRecommender(
+            recommender_type, diversity_level, num_recommendations
+        )
+
+    else:
+        raise ValueError(
+            "Library must be either 'lenskit' or 'recbole'. Make sure the recommender matches your current environment. OWAAAAAA"
+        )

--- a/recommender/factory.py
+++ b/recommender/factory.py
@@ -1,4 +1,26 @@
-def create_recommender(library, recommender_type, diversity_level, num_recommendations):
+from recommender.base_recommender import BaseRecommender
+
+
+def create_recommender(
+    library: str,
+    recommender_type: str,
+    diversity_level: float,
+    num_recommendations: int,
+) -> BaseRecommender:
+    """Creates a recommender based on specifications given by the simulation
+
+    Args:
+        library (str): 'lenskit' or 'recbole' depending on experiment specifications
+        recommender_type (str): type of recommender to create
+        diversity_level (float): level of diversity
+        num_recommendations (int): number of items to recommend (top k)
+
+    Raises:
+        ValueError: Raises if the Library is not specified correctly
+
+    Returns:
+        BaseRecommender: The recommender type matching the specifications
+    """
     if library == "lenskit":
         from recommender.lenskit.lenskit_recommender import LenskitRecommender
 
@@ -15,5 +37,5 @@ def create_recommender(library, recommender_type, diversity_level, num_recommend
 
     else:
         raise ValueError(
-            "Library must be either 'lenskit' or 'recbole'. Make sure the recommender matches your current environment. OWAAAAAA"
+            "Library must be either 'lenskit' or 'recbole'. Make sure the recommender matches your current environment."
         )

--- a/recommender/general_recommender.py
+++ b/recommender/general_recommender.py
@@ -1,0 +1,35 @@
+import random
+import numpy as np
+from recommender.diversity import calculate_diversity
+
+
+def random_recommendation(agent, num_recommendations, add_to_feed=True):
+    """Recommend random news content to an agent"""
+
+    # Get content pool from model and ensure it exists
+    if not hasattr(agent.model, "news_content"):
+        return
+
+    if not agent.model.news_content:
+        return
+
+    # Cache feed set for faster lookups
+    feed_set = set(agent.feed)
+
+    # Get content that isn't in the agent's current feed - use set difference for efficiency
+    available_content = [c for c in agent.model.news_content if c not in feed_set]
+
+    if available_content:
+
+        recommendations = random.sample(available_content, num_recommendations)
+
+        # Apply diversity reranking if enabled (commented out in original)
+        if add_to_feed:
+            agent.recommended_content.extend(recommendations)
+        else:
+            return recommendations
+
+        # After reranking
+        topic_vectors = np.array([rec.topic_vector for rec in recommendations])
+        diversity_score = calculate_diversity(topic_vectors)
+        agent.diversity_score = diversity_score

--- a/recommender/lenskit/lenskit_recommender.py
+++ b/recommender/lenskit/lenskit_recommender.py
@@ -13,10 +13,11 @@ from lenskit import recommend
 # Local imports
 from recommender.diversity import calculate_diversity, diversity_reranking
 from recommender.types import RecommenderType
+from recommender.general_recommender import random_recommendation
 from utils.metrics import vec_mat_cosine_similarity
 
 
-class Recommender:
+class LenskitRecommender:
     def __init__(self, recommender_type, diversity_level, num_recommendations):
         self.type = recommender_type
         self.diversity_level = diversity_level
@@ -64,7 +65,7 @@ class Recommender:
 
         for agent in agents:
             if self.type == RecommenderType.RANDOM.value:
-                self.random_recommendation(agent)
+                random_recommendation(agent, self.num_recommendations)
             elif self.type == RecommenderType.ITEM_KNN.value:
                 self.collaborative_filtering(agent, "item")
             elif self.type == RecommenderType.USER_KNN.value:
@@ -150,7 +151,7 @@ class Recommender:
         try:
             # Get content pool from model
             if not hasattr(agent.model, "news_content") or not agent.model.news_content:
-                self.random_recommendation(agent)
+                random_recommendation(agent, self.num_recommendations)
                 return
 
             interaction_list = self._get_interaction_list()
@@ -165,7 +166,9 @@ class Recommender:
             )  # Minimum total interactions needed
             if n_interactions < min_interactions or user_interactions_count < 3:
                 # Fall back to random recommendations if not enough data overall
-                recommendations = self.random_recommendation(agent, add_to_feed=False)
+                recommendations = random_recommendation(
+                    agent, self.num_recommendations, add_to_feed=False
+                )
                 agent.recommended_content.extend(recommendations)
                 agent.diversity_score = calculate_diversity(
                     np.array([rec.topic_vector for rec in recommendations])
@@ -175,7 +178,7 @@ class Recommender:
             # Create dataset only if needed
             dataset = self._create_dataset()
             if dataset is None:
-                self.random_recommendation(agent)
+                random_recommendation(agent, self.num_recommendations)
                 return
 
             # Create and train pipeline if not already created or if it needs retraining
@@ -239,7 +242,7 @@ class Recommender:
                     # get the first half of the recommendations
                     if len(recommendations) < num_recommendations:
                         recommendations.extend(
-                            self.random_recommendation(
+                            random_recommendation(
                                 agent,
                                 num_recommendations - len(recommendations),
                                 add_to_feed=False,
@@ -283,16 +286,16 @@ class Recommender:
                     agent.diversity_score = diversity_score
                 else:
                     # Fall back to random if no recommendations were generated
-                    self.random_recommendation(agent)
+                    random_recommendation(agent, self.num_recommendations)
             except Exception as e:
                 print(f"Error getting recommendations: {e}")
                 traceback.print_exc()  # Add traceback for better debugging
-                self.random_recommendation(agent)
+                random_recommendation(agent, self.num_recommendations)
 
         except Exception as e:
             print(f"Error in collaborative filtering for agent {agent.pos}: {e}")
             # Fallback to random recommendations
-            self.random_recommendation(agent)
+            random_recommendation(agent, self.num_recommendations)
 
     def content_based(self, agent):
         """Recommend content based on topic vector similarity."""
@@ -378,42 +381,6 @@ class Recommender:
         agent.recommended_content.extend(recommendations)
         agent.diversity_score = diversity_score
 
-    def random_recommendation(self, agent, num_recommendations=None, add_to_feed=True):
-        """Recommend random news content to an agent"""
-
-        interaction_list = self._get_interaction_list()
-        # Use provided num_recommendations or default to self.num_recommendations
-        if num_recommendations is None:
-            num_recommendations = self.num_recommendations
-
-        # Get content pool from model and ensure it exists
-        if not hasattr(agent.model, "news_content"):
-            return
-
-        if not agent.model.news_content:
-            return
-
-        # Cache feed set for faster lookups
-        feed_set = set(agent.feed)
-
-        # Get content that isn't in the agent's current feed - use set difference for efficiency
-        available_content = [c for c in agent.model.news_content if c not in feed_set]
-
-        if available_content:
-
-            recommendations = random.sample(available_content, num_recommendations)
-
-            # Apply diversity reranking if enabled (commented out in original)
-            if add_to_feed:
-                agent.recommended_content.extend(recommendations)
-            else:
-                return recommendations
-
-            # After reranking
-            topic_vectors = np.array([rec.topic_vector for rec in recommendations])
-            diversity_score = calculate_diversity(topic_vectors)
-            agent.diversity_score = diversity_score
-
     def popular_recommendation(self, agent):
         """Recommend popular news content to an agent with personalization and exploration"""
 
@@ -426,7 +393,9 @@ class Recommender:
 
         # Create a dataset from interactions if we have enough
         if n_interactions < 10:  # Need some minimum interactions
-            recommendations = self.random_recommendation(agent, add_to_feed=False)
+            recommendations = random_recommendation(
+                agent, self.num_recommendations, add_to_feed=False
+            )
             agent.recommended_content.extend(recommendations)
             agent.diversity_score = calculate_diversity(
                 np.array([rec.topic_vector for rec in recommendations])
@@ -559,7 +528,7 @@ class Recommender:
             print(f"Error in popular recommendation: {e}")
             traceback.print_exc()
             # Fall back to random recommendations
-            self.random_recommendation(agent)
+            random_recommendation(agent, self.num_recommendations)
 
     def _optimized_diversity_reranking(
         self, preference_vector, recommendations, k=10, pre_calculated=None

--- a/recommender/lenskit/lenskit_recommender.py
+++ b/recommender/lenskit/lenskit_recommender.py
@@ -11,13 +11,15 @@ from lenskit.pipeline import topn_pipeline
 from lenskit import recommend
 
 # Local imports
+from recommender.base_recommender import BaseRecommender
 from recommender.diversity import calculate_diversity, diversity_reranking
 from recommender.types import RecommenderType
 from recommender.general_recommender import random_recommendation
 from utils.metrics import vec_mat_cosine_similarity
 
 
-class LenskitRecommender:
+class LenskitRecommender(BaseRecommender):
+
     def __init__(self, recommender_type, diversity_level, num_recommendations):
         self.type = recommender_type
         self.diversity_level = diversity_level

--- a/recommender/recbole/recbole_recommender.py
+++ b/recommender/recbole/recbole_recommender.py
@@ -1,9 +1,15 @@
+# NB! This is not completed yet. DO NOT attempt to run 'python experiments.py recbole'
+
+# Make sure that a virtual environment with requirements/recbole.txt is installed before running.
+# To avoid red lines set the VSCode interpreter path to your specified environment. Example: .envs/recbole/bin/python
+
 import os
 
 import numpy as np
 import pandas as pd
 import torch
 
+from recommender.base_recommender import BaseRecommender
 from recommender.general_recommender import random_recommendation
 from recbole.config import Config
 from recbole.model.abstract_recommender import AbstractRecommender
@@ -13,7 +19,8 @@ from recbole.utils import get_model
 from recbole.trainer import Trainer
 
 
-class RecboleRecommender:
+class RecboleRecommender(BaseRecommender):
+
     def __init__(self, recommender_type, diversity_level, num_recommendations):
         self.type = recommender_type
         self.diversity_level = diversity_level
@@ -50,9 +57,9 @@ class RecboleRecommender:
                 "eval_batch_size": 2048,
                 # avoid GPU complications
                 "device": "cpu",
-                "checkpoint_dir": f"saved/saved_{os.getpid()}",
+                "checkpoint_dir": f"saved/saved_{os.getpid()}",  # Ensure unique checkpoint for each Trainer
                 "save_dataset": False,
-                # disable logging to avoid thread exhaustion
+                # disable logging to avoid thread exhaustion (DOES NOT WORK, wth)
                 "log_tensorboard": False,
                 "enable_wandb": False,
             },
@@ -97,10 +104,17 @@ class RecboleRecommender:
                 for agent in agents:
                     random_recommendation(agent, self.num_recommendations)
 
+    # TODO: Not properly implemented, needs rewriting if recbole is to be included in experiments
     def train_recommender(self, agents):
+        """Trains a recommender based on what type of model is specified.
+
+        Args:
+            agents (_type_): _description_
+        """
         interaction_list = self._get_interaction_list()
         n_interactions = len(interaction_list)
 
+        # If there are too few interactions overall, return
         if n_interactions < self._training_threshold:
             return
 
@@ -143,7 +157,15 @@ class RecboleRecommender:
                 agent.recommended_content.extend(recs_to_content)
 
     def recommend_topk(self, dataset, user_id):
+        """Recommends the top k items scored by a recommender
 
+        Args:
+            dataset: collection of every user-item interaction
+            user_id (int): unique identifier of the agent the recommendation is for
+
+        Returns:
+            Tensor: the ids of items to be recommended
+        """
         uid = dataset.token2id(dataset.uid_field, str(user_id))
         interaction = {dataset.uid_field: torch.tensor([uid])}
 
@@ -161,54 +183,16 @@ class RecboleRecommender:
         return item_ids
 
     def _create_dataset(self):
-        """Create a LensKit Dataset from interactions"""
+        """Create a recbole Dataset from interactions"""
         if not self.user_interactions:
             return None
 
         interaction_list = self._get_interaction_list()
         n_interactions = len(interaction_list)
 
-        os.makedirs(f"dataset/simulation_{os.getpid()}", exist_ok=True)
-
-        # Convert interactions to DataFrame
-        # df = pd.DataFrame(interaction_list)
-
-        # df = df.rename(
-        #     columns={
-        #         "user_id": "user_id:token",
-        #         "item_id": "item_id:token",
-        #         "rating": "rating:float",
-        #     }
-        # )
-
-        # # Ensure proper data types
-        # df["user_id:token"] = df["user_id:token"].astype("int32")
-        # df["item_id:token"] = df["item_id:token"].astype("int32")
-        # df["rating:float"] = df["rating:float"].astype("float64")
-
-        # # Remove duplicates keeping most recent
-        # df = df.drop_duplicates(["user_id:token", "item_id:token"], keep="last")
-
-        # df.to_csv(
-        #     f"dataset/simulation_{os.getpid()}/simulation_{os.getpid()}.inter",
-        #     sep="\t",
-        #     index=False,
-        # )
-
-        # # Create dataset using from_interactions_df
-        # try:
-        #     config = Config(
-        #         model=self.type,
-        #         dataset=f"simulation_{os.getpid()}",
-        #         config_dict={
-        #             "USER_ID_FIELD": "user_id",
-        #             "ITEM_ID_FIELD": "item_id",
-        #             "RATING_FIELD": "rating",
-        #             "load_col": {"inter": ["user_id", "item_id", "rating"]},
-        #         },
-        #     )
-
-        #     dataset = create_dataset(config)
+        os.makedirs(
+            f"dataset/simulation_{os.getpid()}", exist_ok=True
+        )  # Ensure separation of datasets between threads
 
         df = pd.DataFrame(interaction_list)
 

--- a/recommender/recbole/recbole_recommender.py
+++ b/recommender/recbole/recbole_recommender.py
@@ -1,0 +1,266 @@
+import os
+
+import numpy as np
+import pandas as pd
+import torch
+
+from recommender.general_recommender import random_recommendation
+from recbole.config import Config
+from recbole.model.abstract_recommender import AbstractRecommender
+from recbole.data import create_dataset, data_preparation
+from recbole.data.interaction import Interaction
+from recbole.utils import get_model
+from recbole.trainer import Trainer
+
+
+class RecboleRecommender:
+    def __init__(self, recommender_type, diversity_level, num_recommendations):
+        self.type = recommender_type
+        self.diversity_level = diversity_level
+        self.num_recommendations = num_recommendations
+        self.user_interactions = {}  # Dict to store user interactions
+        self.user_interactions_count = (
+            {}
+        )  # Dict to store number of interactions with specific user for collaborative filtering
+
+        self._user_interactions_cache = []
+        self._user_interactions_cache_dirty = True
+
+        self._last_training_count = (
+            0  # Add this line to track when retraining is needed
+        )
+        self._training_threshold = 200
+        self._last_training_count = 0
+        self._retrain = False
+
+        self.recbole_model: AbstractRecommender
+        self.config = Config(
+            model=self.type,
+            dataset=f"simulation_{os.getpid()}",
+            config_dict={
+                "USER_ID_FIELD": "user_id",
+                "ITEM_ID_FIELD": "item_id",
+                "RATING_FIELD": "rating",
+                "load_col": {"inter": ["user_id", "item_id", "rating"]},
+                # implicit feedback
+                "neg_sampling": {"uniform": 1},
+                # keep training fast for simulation
+                "epochs": 10,
+                "train_batch_size": 2048,
+                "eval_batch_size": 2048,
+                # avoid GPU complications
+                "device": "cpu",
+                "checkpoint_dir": f"saved/saved_{os.getpid()}",
+                "save_dataset": False,
+                # disable logging to avoid thread exhaustion
+                "log_tensorboard": False,
+                "enable_wandb": False,
+            },
+        )
+
+        self.content_dict_cache = {}  # Add cache for content dictionaries
+        self.last_content_update = -1  # Track when content was last updated
+        print(
+            f"Recommender type: {self.type}, diversity_level: {self.diversity_level}, num_recommendations: {self.num_recommendations}"
+        )
+
+    def add_interaction(self, agent_id, content_id, rating):
+        """Add an interaction between an agent and content item"""
+        # Validate inputs
+        if not isinstance(agent_id, (int, np.integer)):
+            agent_id = int(agent_id)
+        if not isinstance(content_id, (int, np.integer)):
+            content_id = int(content_id)
+
+        # Ensure rating is between 0 and 1
+        rating = max(0.0, min(1.0, float(rating)))
+
+        if (agent_id, content_id) not in self.user_interactions:
+            self.user_interactions_count[agent_id] = (
+                self.user_interactions_count.get(agent_id, 0) + 1
+            )
+
+        # Create new interaction, overwrites preexisting interaction
+        self.user_interactions[(agent_id, content_id)] = {
+            "user_id": agent_id,
+            "item_id": content_id,
+            "rating": rating,
+        }
+
+        self._user_interactions_cache_dirty = True
+
+    def update_recommendations(self, agents):
+        match self.type:
+            case "BPR":
+                self.train_recommender(agents)
+            case "random":
+                for agent in agents:
+                    random_recommendation(agent, self.num_recommendations)
+
+    def train_recommender(self, agents):
+        interaction_list = self._get_interaction_list()
+        n_interactions = len(interaction_list)
+
+        if n_interactions < self._training_threshold:
+            return
+
+        if n_interactions - self._last_training_count < self._training_threshold:
+            return
+
+        dataset = self._create_dataset()
+
+        if dataset is None:
+            for agent in agents:
+                random_recommendation(agent, self.num_recommendations)
+            return
+
+        else:
+            model_class = get_model(self.type)
+            self.recbole_model = model_class(self.config, dataset)
+
+            trainer = Trainer(self.config, self.recbole_model)
+            train_data, val_data, test_data = data_preparation(self.config, dataset)
+
+            try:
+                trainer.fit(train_data)
+            except RuntimeError as e:
+                # Suppress TensorBoard thread errors during parallel execution
+                if "can't start new thread" in str(e):
+                    pass
+                else:
+                    raise
+
+        # TODO: MOVE
+
+        for agent in agents:
+            if agent.pos not in dataset.field2id_token[dataset.uid_field]:
+                random_recommendation(agent, self.num_recommendations)
+
+            else:
+                topk_recs = self.recommend_topk(dataset, agent.pos)
+                recs_to_content = [agent.model.news_content[item] for item in topk_recs]
+
+                agent.recommended_content.extend(recs_to_content)
+
+    def recommend_topk(self, dataset, user_id):
+
+        uid = dataset.token2id(dataset.uid_field, str(user_id))
+        interaction = {dataset.uid_field: torch.tensor([uid])}
+
+        scores = self.recbole_model.full_sort_predict(interaction)
+
+        already_interacted = dataset.history_item_matrix()[0][uid]
+        scores[already_interacted] = -float("inf")
+
+        topk_scores, topk_items = torch.topk(scores, self.num_recommendations)
+
+        item_ids = [
+            int(dataset.id2token(dataset.iid_field, iid)) for iid in topk_items.tolist()
+        ]
+
+        return item_ids
+
+    def _create_dataset(self):
+        """Create a LensKit Dataset from interactions"""
+        if not self.user_interactions:
+            return None
+
+        interaction_list = self._get_interaction_list()
+        n_interactions = len(interaction_list)
+
+        os.makedirs(f"dataset/simulation_{os.getpid()}", exist_ok=True)
+
+        # Convert interactions to DataFrame
+        # df = pd.DataFrame(interaction_list)
+
+        # df = df.rename(
+        #     columns={
+        #         "user_id": "user_id:token",
+        #         "item_id": "item_id:token",
+        #         "rating": "rating:float",
+        #     }
+        # )
+
+        # # Ensure proper data types
+        # df["user_id:token"] = df["user_id:token"].astype("int32")
+        # df["item_id:token"] = df["item_id:token"].astype("int32")
+        # df["rating:float"] = df["rating:float"].astype("float64")
+
+        # # Remove duplicates keeping most recent
+        # df = df.drop_duplicates(["user_id:token", "item_id:token"], keep="last")
+
+        # df.to_csv(
+        #     f"dataset/simulation_{os.getpid()}/simulation_{os.getpid()}.inter",
+        #     sep="\t",
+        #     index=False,
+        # )
+
+        # # Create dataset using from_interactions_df
+        # try:
+        #     config = Config(
+        #         model=self.type,
+        #         dataset=f"simulation_{os.getpid()}",
+        #         config_dict={
+        #             "USER_ID_FIELD": "user_id",
+        #             "ITEM_ID_FIELD": "item_id",
+        #             "RATING_FIELD": "rating",
+        #             "load_col": {"inter": ["user_id", "item_id", "rating"]},
+        #         },
+        #     )
+
+        #     dataset = create_dataset(config)
+
+        df = pd.DataFrame(interaction_list)
+
+        df = df[["user_id", "item_id", "rating"]]
+
+        df["user_id"] = df["user_id"].astype("int32")
+        df["item_id"] = df["item_id"].astype("int32")
+        df["rating"] = df["rating"].astype("float64")
+
+        df = df.drop_duplicates(["user_id", "item_id"], keep="last")
+        df_to_save = df.rename(
+            columns={
+                "user_id": "user_id:token",
+                "item_id": "item_id:token",
+                "rating": "rating:float",
+            }
+        )
+        df_to_save.to_csv(
+            f"dataset/simulation_{os.getpid()}/simulation_{os.getpid()}.inter",
+            sep="\t",
+            index=False,
+        )
+
+        try:
+            config = Config(
+                model=self.type,
+                dataset=f"simulation_{os.getpid()}",
+                config_dict={
+                    "USER_ID_FIELD": "user_id",
+                    "ITEM_ID_FIELD": "item_id",
+                    "RATING_FIELD": "rating",
+                    "load_col": {
+                        "inter": {
+                            "user_id": "user_id:token",
+                            "item_id": "item_id:token",
+                            "rating": "rating:float",
+                        }
+                    },
+                },
+            )
+
+            dataset = create_dataset(config)
+
+            return dataset
+
+        except Exception as e:
+            print(f"Error creating dataset: {e}")
+            return None
+
+    def _get_interaction_list(self):
+        if self._user_interactions_cache_dirty:
+            self._user_interactions_cache = list(self.user_interactions.values())
+            self._user_interactions_cache_dirty = False
+
+        return self._user_interactions_cache

--- a/recommender/recommender.py
+++ b/recommender/recommender.py
@@ -32,6 +32,8 @@ class Recommender:
         self._last_training_count = (
             0  # Add this line to track when retraining is needed
         )
+        self._training_threshold = 200
+
         self.content_dict_cache = {}  # Add cache for content dictionaries
         self.last_content_update = -1  # Track when content was last updated
         print(

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,3 +17,5 @@ matplotlib
 seaborn
 solara
 
+# config
+pyyaml

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,10 +11,10 @@ infomap
 
 # ABM
 mesa
-lenskit>=2025.1.0
 altair
 
 # Data Visualization
 matplotlib
 seaborn
 solara
+

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,5 @@
 # Data Processing
-pandas
-numpy
+numpy==1.26.1
 scikit-learn
 
 # Social network

--- a/requirements/lenskit.txt
+++ b/requirements/lenskit.txt
@@ -1,0 +1,3 @@
+-r base.txt
+
+lenskit>=2025.1.0

--- a/requirements/recbole.txt
+++ b/requirements/recbole.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+recbole
+torch==2.3.1

--- a/requirements/recbole.txt
+++ b/requirements/recbole.txt
@@ -2,3 +2,4 @@
 
 recbole
 torch==2.3.1
+pandas==1.5.3

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -124,6 +124,12 @@ def calculate_cluster_content_similarity(model):
         # First time - detect communities
         try:
             import infomap
+            import os
+
+            # Disable OpenMP threading in infomap to avoid conflicts with Solara
+            os.environ["OMP_NUM_THREADS"] = "1"
+            os.environ["OPENBLAS_NUM_THREADS"] = "1"
+            os.environ["MKL_NUM_THREADS"] = "1"
 
             # Create an Infomap instance with fixed seed for reproducibility
             im = infomap.Infomap("--directed --silent --seed 42")
@@ -307,6 +313,7 @@ def calculate_diversity_improvement(model):
 
     return (total_improvement / count * 100) if count > 0 else 0
 
+
 def calculate_mean_degree_by_dominant_personality(model, trait_index, mode="in"):
     G = model.social_media_platform.social_network.network
     P = np.asarray(model.personality_vectors, dtype=float)
@@ -316,10 +323,13 @@ def calculate_mean_degree_by_dominant_personality(model, trait_index, mode="in")
     dom = np.argmax(P, axis=1)
     reg_mask = _regular_user_mask(model)
 
-    deg = np.array([
-        G.in_degree(i) if mode == "in" else G.out_degree(i)
-        for i in range(model.num_agents)
-    ], dtype=float)
+    deg = np.array(
+        [
+            G.in_degree(i) if mode == "in" else G.out_degree(i)
+            for i in range(model.num_agents)
+        ],
+        dtype=float,
+    )
 
     mask = (dom == trait_index) & reg_mask
     return float(np.mean(deg[mask])) if np.any(mask) else 0.0
@@ -334,7 +344,8 @@ def calculate_count_by_dominant_personality(model, trait_index):
     reg_mask = _regular_user_mask(model)
     return int(np.sum((dom == trait_index) & reg_mask))
 
-#def update_personality_degree_stats(model):
+
+# def update_personality_degree_stats(model):
 #    G = model.social_media_platform.social_network.network
 #
 #    P = np.asarray(model.personality_vectors, dtype=float)
@@ -402,7 +413,6 @@ def matrix_cosine_similarity(matrix):
     return x_normalized @ x_normalized.T
 
 
-
 def _regular_user_mask(model):
     """
     Boolean mask selecting only regular users (exclude influencers + bots)
@@ -412,8 +422,7 @@ def _regular_user_mask(model):
     n_inf = int(model.influencer_percentage * N)
     n_bot = int(model.bot_percentage * N)
     mask = np.ones(N, dtype=bool)
-    mask[:n_inf] = False                # exclude influencers
+    mask[:n_inf] = False  # exclude influencers
     if n_bot > 0:
-        mask[N - n_bot:] = False        # exclude bots
+        mask[N - n_bot :] = False  # exclude bots
     return mask
-


### PR DESCRIPTION
Splits the recommender.py into two files which use either the lenskit or recbole library.

WHY: Lenskit and recbole are as of now incompatible with each other as recbole uses torch < 2.4, while lenskit depends on torch >= 2.4.

Changes: 
- New repository structure with an Abstract class BaseRecommender which defines both LenskitRecommender and RecboleRecommender. They are constructed by factory.py.
- New argument needs to be passed when running experiments.py.  Defaults to lenskit
`python experiments.py lenskit`
- Requirements are now split up between the two libraries. It is recommended to create two different environments and switch between them depending on what is necessary.


IMPORTANT NOTE: The recbole part is as of now not functional. The issue arises from recboles logging of training with log_tensorboard. These threads seem to not resolve properly, and the simulation eventually runs out of threads to deploy. As of now there is not a proper way of disabling this logging based on what I could find. As such, recbole experimentation has to wait until this can be resolved. 
