### PR TITLE
BiasedMF parameters

### DIFF
--- a/experiments.py
+++ b/experiments.py
@@ -108,7 +108,8 @@ def run_recommender_comparison_experiment(
             "popular",
             "hybrid_weighted_static",
             "hybrid_weighted_dynamic",
-            "matrix_factorization" "mixed",
+            "matrix_factorization",
+            "mixed"
         ],
         "max_steps": max_steps,
         "collect_personality_degree_stats": False,

--- a/recommender/recommender.py
+++ b/recommender/recommender.py
@@ -59,10 +59,13 @@ class Recommender:
         self.pipeline = None
 
         # Biased Matrix Factorization model
+
+        # Paramteres for BiasedMFScorer was decided through parameter tuning
         self.mf_model = BiasedMFScorer(
-            embedding_size=20,  # Number of latent factors
-            epochs=20,  # Number of iterations for training
+            embedding_size=32,  # Number of latent factors
+            epochs=40,  # Number of iterations for training
             regularization=0.1,  # Regularization parameter
+            damping=15,  # Damping factor for bias terms
         )
 
         self.mf_pipeline = None  # Pipeline for matrix factorization model


### PR DESCRIPTION
new parameters for Biased MF based on results from parameter tuning experiments

the current:
- embedding_size = 32
- epochs = 40
- regularization = 0.1
- damping = 15.0